### PR TITLE
Make ToStrictString public for DataMinerVersion.

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -20,18 +20,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-	    <None Include="..\README.md">
-		    <Pack>True</Pack>
-		    <PackagePath>\</PackagePath>
-	    </None>
-        <None Include="..\_NuGetItems\icon.png">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-        <None Include="..\_NuGetItems\LICENSE.txt">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
+	    <None Include="..\README.md" Pack="True" PackagePath="" />
+        <None Include="..\_NuGetItems\icon.png" Pack="True" PackagePath="" />
+        <None Include="..\_NuGetItems\LICENSE.txt" Pack="True" PackagePath="" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Common/DataMinerVersion.cs
+++ b/Common/DataMinerVersion.cs
@@ -351,7 +351,7 @@
         /// Spaces are removed, expected format: X.X.X.X or X.X.X.X-X.
         /// </summary>
         /// <returns>The String representation of this <see cref="DataMinerVersion"/> object.</returns>
-        internal string ToStrictString()
+        public string ToStrictString()
         {
             return Iteration > 0
                 ? $"{Version}-{Iteration}"


### PR DESCRIPTION
Useful for AppPackage creation as the minimum supported DM version requires the strict format.